### PR TITLE
ftest(#85): check prop types of plain JS components

### DIFF
--- a/packages/vue-virtual-textdocument/test/__snapshots__/baseline.spec.ts.snap
+++ b/packages/vue-virtual-textdocument/test/__snapshots__/baseline.spec.ts.snap
@@ -166,6 +166,19 @@ export function render({/*@@vue:identifiers-start*/name/*@@vue:identifiers-end*/
 }
 `;
 
+exports[`VueVirtualDocument/baseline feature-diagnostics/src/ComponentPropUsage.vue 1`] = `
+import _Ctx from './ComponentPropUsage.vue?internal'
+import HelloWorld from './components/HelloWorld.vue'
+
+
+declare const __completionsTrigger: InstanceType<typeof _Ctx>
+__completionsTrigger./*@@vue:completions*/$props
+const __completionsTag = /*@@vue:completionsTag*/<div />
+export function render(_ctx: InstanceType<typeof _Ctx>) {
+  return /*@@vue:start*/<><img alt="Vue logo" src="./assets/logo.png" /><HelloWorld msg={123} /></>/*@@vue:end*/
+}
+`;
+
 exports[`VueVirtualDocument/baseline feature-diagnostics/src/FeatureSetup.vue 1`] = `
 import _Ctx from './FeatureSetup.vue?internal'
 
@@ -432,6 +445,18 @@ export function render(_ctx: InstanceType<typeof _Ctx>) {
 `;
 
 exports[`VueVirtualDocument/baseline feature-diagnostics/src/components/Example.Pascal.Component.vue 1`] = ``;
+
+exports[`VueVirtualDocument/baseline feature-diagnostics/src/components/HelloWorld.vue 1`] = `
+import _Ctx from './HelloWorld.vue?internal'
+
+
+declare const __completionsTrigger: InstanceType<typeof _Ctx>
+__completionsTrigger./*@@vue:completions*/$props
+const __completionsTag = /*@@vue:completionsTag*/<div />
+export function render({/*@@vue:identifiers-start*/msg/*@@vue:identifiers-end*/,..._ctx}: InstanceType<typeof _Ctx>) {
+  return /*@@vue:start*/<><h1 >{msg}</h1></>/*@@vue:end*/
+}
+`;
 
 exports[`VueVirtualDocument/baseline feature-diagnostics/src/components/JavaScriptPropsOption.vue 1`] = ``;
 

--- a/samples/feature-diagnostics/src/ComponentPropUsage.vue
+++ b/samples/feature-diagnostics/src/ComponentPropUsage.vue
@@ -1,0 +1,15 @@
+<template>
+  <img alt="Vue logo" src="./assets/logo.png" />
+  <HelloWorld :msg="123" />
+</template>
+
+<script>
+import HelloWorldVue from "./components/HelloWorld.vue";
+import { defineComponent } from "vue";
+export default defineComponent({
+  name: "App",
+  components: {
+    HelloWorld: HelloWorldVue,
+  },
+});
+</script>

--- a/samples/feature-diagnostics/src/components/HelloWorld.vue
+++ b/samples/feature-diagnostics/src/components/HelloWorld.vue
@@ -1,0 +1,12 @@
+<template>
+  <h1>{{ msg }}</h1>
+</template>
+
+<script>
+export default {
+  name: "HelloWorld",
+  props: {
+    msg: String,
+  },
+};
+</script>

--- a/test/baseline/diagnostics.spec.ts
+++ b/test/baseline/diagnostics.spec.ts
@@ -170,21 +170,23 @@ describe('diagnostic', () => {
       ])
 
       expect(body?.diagnostics).toEqual(
-        expected.map((item) => expect.objectContaining({
-          category: 'error',
-          code: 2322,
-          text: expect.stringContaining(
-            `Type '{}' is missing the following properties from type`,
-          ),
-          start: {
-            line: item.line,
-            offset: item.offset,
-          },
-          end: {
-            line: item.line,
-            offset: expect.any(Number),
-          },
-        })),
+        expected.map((item) =>
+          expect.objectContaining({
+            category: 'error',
+            code: 2322,
+            text: expect.stringContaining(
+              `Type '{}' is missing the following properties from type`,
+            ),
+            start: {
+              line: item.line,
+              offset: item.offset,
+            },
+            end: {
+              line: item.line,
+              offset: expect.any(Number),
+            },
+          }),
+        ),
       )
     } finally {
       await server.sendCommand('updateOpen', { closedFiles: [file] })
@@ -237,33 +239,35 @@ describe('diagnostic', () => {
       ])
 
       expect(body?.diagnostics).toEqual(
-        expected.map((item) => expect.objectContaining({
-          category: 'error',
-          code: 2741,
-          text: expect.stringContaining(
-            `Property 'id' is missing in type '{}' but required in type 'Event'.`,
-          ),
-          start: {
-            line: item.line,
-            offset: item.offset,
-          },
-          end: {
-            line: item.line,
-            offset: expect.any(Number),
-          },
-          relatedInformation: [
-            {
-              category: 'message',
-              code: 2728,
-              message: `'id' is declared here.`,
-              span: {
-                start: expect.any(Object),
-                end: expect.any(Object),
-                file: expect.stringMatching(/\.vue$/),
-              },
+        expected.map((item) =>
+          expect.objectContaining({
+            category: 'error',
+            code: 2741,
+            text: expect.stringContaining(
+              `Property 'id' is missing in type '{}' but required in type 'Event'.`,
+            ),
+            start: {
+              line: item.line,
+              offset: item.offset,
             },
-          ],
-        })),
+            end: {
+              line: item.line,
+              offset: expect.any(Number),
+            },
+            relatedInformation: [
+              {
+                category: 'message',
+                code: 2728,
+                message: `'id' is declared here.`,
+                span: {
+                  start: expect.any(Object),
+                  end: expect.any(Object),
+                  file: expect.stringMatching(/\.vue$/),
+                },
+              },
+            ],
+          }),
+        ),
       )
     } finally {
       await server.sendCommand('updateOpen', { closedFiles: [file] })
@@ -316,21 +320,48 @@ describe('diagnostic', () => {
       ])
 
       expect(body?.diagnostics).toEqual(
-        expected.map((item) => expect.objectContaining({
-          category: 'error',
-          code: 2322,
-          text: expect.stringContaining(
-            `Type '{ id: number; unknown: string; }' is not assignable to type 'Event'.`,
-          ),
-          start: {
-            line: item.line,
-            offset: item.offset,
-          },
-          end: {
-            line: item.line,
-            offset: expect.any(Number),
-          },
-        })),
+        expected.map((item) =>
+          expect.objectContaining({
+            category: 'error',
+            code: 2322,
+            text: expect.stringContaining(
+              `Type '{ id: number; unknown: string; }' is not assignable to type 'Event'.`,
+            ),
+            start: {
+              line: item.line,
+              offset: item.offset,
+            },
+            end: {
+              line: item.line,
+              offset: expect.any(Number),
+            },
+          }),
+        ),
+      )
+    } finally {
+      await server.sendCommand('updateOpen', { closedFiles: [file] })
+    }
+  })
+
+  test('detects wrong prop type in plain JS component', async () => {
+    const file = abs(`src/ComponentPropUsage.vue`)
+    try {
+      await server.sendCommand('updateOpen', {
+        openFiles: [{ file, projectRootPath }],
+      })
+
+      const { body } = await server.waitForEvent(
+        'semanticDiag',
+        checkEventFile(file),
+      )
+
+      expect(body?.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 2322,
+            text: expect.stringContaining(`Type 'number' is not assignable to type`),
+          }),
+        ]),
       )
     } finally {
       await server.sendCommand('updateOpen', { closedFiles: [file] })
@@ -383,21 +414,23 @@ describe('diagnostic', () => {
       ])
 
       expect(body?.diagnostics).toEqual(
-        expected.map((item) => expect.objectContaining({
-          category: 'error',
-          code: 2322,
-          text: expect.stringContaining(
-            `Type 'number' is not assignable to type`,
-          ),
-          start: {
-            line: item.line,
-            offset: item.offset,
-          },
-          end: {
-            line: item.line,
-            offset: expect.any(Number),
-          },
-        })),
+        expected.map((item) =>
+          expect.objectContaining({
+            category: 'error',
+            code: 2322,
+            text: expect.stringContaining(
+              `Type 'number' is not assignable to type`,
+            ),
+            start: {
+              line: item.line,
+              offset: item.offset,
+            },
+            end: {
+              line: item.line,
+              offset: expect.any(Number),
+            },
+          }),
+        ),
       )
     } finally {
       await server.sendCommand('updateOpen', { closedFiles: [file] })
@@ -408,7 +441,7 @@ describe('diagnostic', () => {
     `%s should have no semantic errors`,
     async (fileName) => {
       const file = abs(`src/${fileName}`)
-      
+
       try {
         await server.sendCommand('updateOpen', {
           openFiles: [{ file, projectRootPath }],


### PR DESCRIPTION
Typechecking props of JS components requires `jsconfig.json` with `"checkJS": true` and `"strict": true`.

closes #85
