### PR TITLE
chore(readme): fix icon links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,21 +8,28 @@
 
 <div style="display: flex; justify-content: center; text-align: center">  
   <div style="margin: 16px">
-    <img src="./extensions/vscode-vue-language-features/logo.png" width="96" />
+    <a href="https://marketplace.visualstudio.com/items?itemName=znck.vue-language-features">
+      <img src="./extensions/vscode-vue-language-features/logo.png" width="96" />
+    </a>
     <h3>
       <a href="https://marketplace.visualstudio.com/items?itemName=znck.vue-language-features">Language Features</a>
     </h3>
+    </a>
   </div>
-  
+
   <div style="margin: 16px">
-    <img src="./assets/preview.png" width="96" />
+    <a href="https://github.com/znck/preview">
+      <img src="./assets/preview.png" width="96" />
+    </a>
     <h3>
       <a href="https://github.com/znck/preview">Preview</a>
     </h3>
   </div>
 
   <div style="margin: 16px">
-    <img src="./extensions/vscode-vue/logo.png" width="96" />
+    <a href="https://marketplace.visualstudio.com/items?itemName=znck.vue">
+      <img src="./extensions/vscode-vue/logo.png" width="96" />
+    </a>
     <h3>
       <a href="https://marketplace.visualstudio.com/items?itemName=znck.vue">Syntax Highlight</a>
     </h3>


### PR DESCRIPTION
(aka: first dummy PR :D)

Github automatically adds an `<a>` wrapper for images. [preview](https://github.com/pi0/vue-developer-experience/blob/patch-1/readme.md)