### PR TITLE
fix(#147): update import to support node >= 12.0.0

### DIFF
--- a/packages/typecheck/src/cli.ts
+++ b/packages/typecheck/src/cli.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk'
-import FS from 'fs'
-import FSP from 'fs/promises'
+import FS, { promises as FSP } from 'fs'
 // @ts-expect-error
 import parseArgs from 'minimist'
 import Path from 'path'


### PR DESCRIPTION
To support node versions `>= 12.0.0` with the `typecheck` package, the import of fs-promises has to be changed.

See #147 