### PR TITLE
fix(typecheck): Show `Running for` message only for `raw` format

### DIFF
--- a/packages/typecheck/src/cli.ts
+++ b/packages/typecheck/src/cli.ts
@@ -202,8 +202,11 @@ Options
     console.error(`Cannot find directory: "${String(argv[0])}"`)
     process.exit(1)
   }
+  
+  if (format === 'raw') {
+    console.debug('Running for ' + directory)
+  }
 
-  console.debug('Running for ' + directory)
   if (!FS.statSync(directory).isDirectory()) {
     console.error(
       `Expecting a directory, but "${process.argv[2]}" is not a directory.`,


### PR DESCRIPTION
The extra log makes it impossible to read the output stream as JSON