### PR TITLE
Adding links to contributing and code of conduct files in index.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,3 +60,7 @@ A set of tools for better developer experience aka Vue Developer Experience or V
 - [Vue Syntax Highlight](./extensions/vscode-vue) — provides syntax highlight for VS Code.
 - [Vue Language Features](./extensions/vscode-vue-language-features) — provides typescript integration for VS Code.
 - [Vue Virtual TextDocument](./packages/vue-virtual-textdocument) — creates a virtual file system to represent blocks in SFC as files.
+
+## Contributing
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [How to Build](CONTRIBUTING.md)


### PR DESCRIPTION
To help others find those files thay may easly pass unperceived.

For example how I couldn't find said files at this comment:
https://github.com/znck/vue-developer-experience/issues/162#issuecomment-761753205