### PR TITLE
fix: context.imports.add is not a function

### DIFF
--- a/.changeset/two-spiders-complain.md
+++ b/.changeset/two-spiders-complain.md
@@ -1,0 +1,5 @@
+---
+"@vuedx/compiler-tsx": patch
+---
+
+fix: context.imports.add is not a function

--- a/packages/compiler-tsx/src/transforms/transformElement.ts
+++ b/packages/compiler-tsx/src/transforms/transformElement.ts
@@ -65,7 +65,7 @@ export function createElementTransform(
 
   return (node, context) => {
     if (!isImportAdded) {
-      context.imports.add({
+      context.imports.push({
         exp: '_Ctx',
         path: getInternalPath(options),
       })
@@ -88,7 +88,7 @@ export function createElementTransform(
           options.components[name] ?? options.components[node.tag]
         if ((context.identifiers[name] ?? 0) <= 0) {
           if (component != null) {
-            context.imports.add({
+            context.imports.push({
               exp:
                 component.named === true
                   ? `{ ${


### PR DESCRIPTION
Fix #208
Based on [comment](https://github.com/znck/vue-developer-experience/issues/208#issuecomment-792326949):
> For me this first occurred when `@vue/compiler-core` was updated to `3.0.6`. So downgrading to `3.0.5` is a possible workaround.
> 
> Looking at the commits it seems like the culprit is this one: [vuejs/vue-next@c69f4ea#diff-ed0d861d15952e0e6eb72faeeb444ef4a2325d22d7e5013653307dbe23a496a1](https://github.com/vuejs/vue-next/commit/c69f4ea857b7db8d26bbde2f80786c8212d16770#diff-ed0d861d15952e0e6eb72faeeb444ef4a2325d22d7e5013653307dbe23a496a1)